### PR TITLE
FIX 指令完善，失效链接维护

### DIFF
--- a/工具文档/指令相关/Search指令.md
+++ b/工具文档/指令相关/Search指令.md
@@ -27,7 +27,7 @@
 
 ![](https://images.serverlessfans.com/s-tool/zh/s-search-test-alibaba.jpg)
 
-当然，如果我们想要搜索其他的内容，例如插件或者组件等，我们可以增加对应的参数`-t`，例如我们要搜索阿里巴巴的`test`相关的组件（关于应用、组件和插件的概念可以查看[相关文档](../others/Package概念区分.md)）：`s search test -p alibaba -t component`，结果是：
+当然，如果我们想要搜索其他的内容，例如插件或者组件等，我们可以增加对应的参数`-t`，例如我们要搜索阿里巴巴的`test`相关的组件（关于应用、组件和插件的概念可以查看[相关文档](https://github.com/ServerlessTool/docs/blob/master/%E5%B7%A5%E5%85%B7%E6%96%87%E6%A1%A3/%E5%BF%AB%E9%80%9F%E5%85%A5%E9%97%A8/Package%E6%A6%82%E5%BF%B5%E5%8C%BA%E5%88%86.md)）：`s search test -p alibaba -t component`，结果是：
 
 ![](https://images.serverlessfans.com/s-tool/zh/s-search-test-alibaba-component.jpg)
 


### PR DESCRIPTION
（1）搜索指令支持先输入关键字再输入指定厂商，反之成立：s search -p alibaba nodejs -t component，等同于 s search nodejs -p alibaba -t component，待确定这里是否声明【查看引用的common.js(https://aliyun-wb-b9vfez7zb7.oss-cn-shanghai.aliyuncs.com/fc/pk-1145012359027075/app-2020091000194487/commonjs.jpg?Expires=1600497755&OSSAccessKeyId=TMP.3KiaG4HzPcHT3PB554ECfEkrrkYdxMNTV7H3PFrP4Z3vFbedmqhSTRJjfiWbWiuzuGpwaTj6EyRQPzSoUN2vrgRAk4s3Ny&Signature=yaPvGDpB4IrJgKQDentu893Lbhw%3D)，应该是-t 后跟上component都能执行组件搜索，不跟在-t后异常】		
（2）“相关文档”链接在文档迁移后未更新，新链接地址：https://github.com/ServerlessTool/docs/blob/master/%E5%B7%A5%E5%85%B7%E6%96%87%E6%A1%A3/%E5%BF%AB%E9%80%9F%E5%85%A5%E9%97%A8/Package%E6%A6%82%E5%BF%B5%E5%8C%BA%E5%88%86.md